### PR TITLE
fix: update the source of the tuna

### DIFF
--- a/guide/source/0setup-devel-env.rst
+++ b/guide/source/0setup-devel-env.rst
@@ -104,8 +104,8 @@ Rust 开发环境配置
 
 .. code-block:: bash
 
-   export RUSTUP_DIST_SERVER=https://mirrors.tuna.edu.cn/rustup
-   export RUSTUP_UPDATE_ROOT=https://mirrors.tuna.edu.cn/rustup/rustup
+   export RUSTUP_UPDATE_ROOT=https://mirrors.tuna.tsinghua.edu.cn/rustup/rustup
+   export RUSTUP_DIST_SERVER=https://mirrors.tuna.tsinghua.edu.cn/rustup
    curl https://sh.rustup.rs -sSf | sh
 
 也可以设置科学上网代理：


### PR DESCRIPTION
Signed-off-by: Aucker <aucker2020@gmail.com>

According to this [help manual](https://mirrors.tuna.tsinghua.edu.cn/help/rustup/#:~:text=YYYY%2Dmm%2Ddd-,%E8%8B%A5%E8%A6%81%E9%95%BF%E6%9C%9F%E5%90%AF%E7%94%A8%20TUNA%20%E6%BA%90%EF%BC%8C%E6%89%A7%E8%A1%8C%EF%BC%9A,-%24%20%23%20for%20bash), the link should be changed.