### PR TITLE
修改sceduling.md, 将step0中的create codespace on main 更改为 on edu

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -68,7 +68,7 @@
           
           3.） 完成第二步后，你的rustings实验练习 的 github repository 会被自动建立好，点击此github repository的链接，就可看到你要完成的实验了。
           
-          4.） 在你的第一个实验练习的网页的中上部可以看到一个醒目的 `code`  绿色按钮，点击后，可以进一步看到  `codespace` 标签和醒目的 `create codesapce on main` 绿色按钮。请点击这个绿色按钮，就可以进入到在线的ubuntu +vscode环境中
+          4.） 在你的第一个实验练习的网页的中上部可以看到一个醒目的 `code`  绿色按钮，点击后，可以进一步看到  `codespace` 标签和醒目的 `create codesapce on edu` 绿色按钮。请点击这个绿色按钮，就可以进入到在线的ubuntu +vscode环境中
           
           5.） 再按照下面的环境安装提示在vscode的 `console` 中安装配置开发环境：rustc等工具。注：也可在vscode的 `console` 中执行 ``make codespaces_setenv`` 来自动安装配置开发环境（执行``sudo``需要root权限，仅需要执行一次）。
           


### PR DESCRIPTION
老师您好：
       如参照原文档中选择 `create codesapce on main` ，则需项目在main分支下，但目前该分支下已无Makefile文件，这导致学员无法按照教程上描述的通过make实现环境的安装，故建议将描述改成 `create codesapce on edu` 使学员可在edu分支下通过make实现环境的安装 。以上如有问题请联系，非常感谢。