### PR TITLE
add repr(C) to TaskInfo

### DIFF
--- a/ci-user/user/src/lib.rs
+++ b/ci-user/user/src/lib.rs
@@ -114,6 +114,7 @@ pub struct SyscallInfo {
 
 const MAX_SYSCALL_NUM: usize = 500;
 
+#[repr(C)]
 #[derive(Debug)]
 pub struct TaskInfo {
     pub status: TaskStatus,

--- a/user/src/lib.rs
+++ b/user/src/lib.rs
@@ -114,6 +114,7 @@ pub struct SyscallInfo {
 
 const MAX_SYSCALL_NUM: usize = 500;
 
+#[repr(C)]
 #[derive(Debug)]
 pub struct TaskInfo {
     pub status: TaskStatus,


### PR DESCRIPTION
Since the `TaskInfo` struct will cross the system-call interface, and programs written in C may be linked to the rust kernel, we should make sure that `TaskInfo`'s layout in the C style.

On rust compiler `rustc 1.62.0-nightly (1f7fb6413 2022-04-10)` , the memory layout of the following to structs doesn't same.

When I was doing Lab3, I wrote `#[repr(C)]` in the os kernel, but the user library does not, It took me a lot of time to figure out the problem.

```
#[repr(C)]
pub struct TaskInfo {
    pub status: TaskStatus,
    pub syscall_times: [u32; MAX_SYSCALL_NUM],
    pub time: usize,
}
```

```
pub struct TaskInfo {
    pub status: TaskStatus,
    pub syscall_times: [u32; MAX_SYSCALL_NUM],
    pub time: usize,
}
```