### PR TITLE
add some identify registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ FROM ubuntu:20.04
 ARG QEMU_VERSION=7.0.0
 ARG HOME=/root
 
+# -1. (Optional) Add Ubuntu Repo
+ADD docker/registryList /etc/apt/
+RUN sed -i "1r /etc/apt/registryList" /etc/apt/sources.list
+
 # 0. Install general tools
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \

--- a/docker/registryList
+++ b/docker/registryList
@@ -1,0 +1,11 @@
+# Aliyun Registry For Ubuntu:20.04
+deb http://mirrors.aliyun.com/ubuntu/ focal main restricted universe multiverse
+deb-src http://mirrors.aliyun.com/ubuntu/ focal main restricted universe multiverse
+deb http://mirrors.aliyun.com/ubuntu/ focal-security main restricted universe multiverse
+deb-src http://mirrors.aliyun.com/ubuntu/ focal-security main restricted universe multiverse
+deb http://mirrors.aliyun.com/ubuntu/ focal-updates main restricted universe multiverse
+deb-src http://mirrors.aliyun.com/ubuntu/ focal-updates main restricted universe multiverse
+deb http://mirrors.aliyun.com/ubuntu/ focal-proposed main restricted universe multiverse
+deb-src http://mirrors.aliyun.com/ubuntu/ focal-proposed main restricted universe multiverse
+deb http://mirrors.aliyun.com/ubuntu/ focal-backports main restricted universe multiverse
+deb-src http://mirrors.aliyun.com/ubuntu/ focal-backports main restricted universe multiverse


### PR DESCRIPTION
#39 这是我做的一点点改动，主要做了一下

我在项目的根目录下创建了一个`docker/registryList`，用来存放自定义（就近）的镜像列表，然后在`update`前加入

```sh
ADD docker/registryList /etc/apt/
RUN sed -i.bak "1r /etc/apt/registryList" /etc/apt/sources.list
```

这样，在`make build_docker`的时候，就可以在系统`update`前，加入比较快和稳定的源。

PS: 因为，我这边距离阿里云的距离比较近，所以在`registryList`中我主要添加了阿里云的一些镜像。