### PR TITLE
使用 perl 替换 ci-user/Makefile 中 sed

### DIFF
--- a/ci-user/Makefile
+++ b/ci-user/Makefile
@@ -20,10 +20,10 @@ else ifeq ($(CHAPTER), 8)
 endif
 
 randomize:
-	find user/src/bin -name "*.rs" | xargs sed -i 's/OK/OK$(RAND)/g'
-	find user/src/bin -name "*.rs" | xargs sed -i 's/passed/passed$(RAND)/g'
-	find check -name "*.py" | xargs sed -i 's/OK/OK$(RAND)/g'
-	find check -name "*.py" | xargs sed -i 's/passed/passed$(RAND)/g'
+	find user/src/bin -name "*.rs" | xargs perl -pi -e s,OK,OK$(RAND),g
+	find user/src/bin -name "*.rs" | xargs perl -pi -e s,passed,passed$(RAND),g
+	find check -name "*.py" | xargs perl -pi -e s,OK,OK$(RAND),g
+	find check -name "*.py" | xargs perl -pi -e s,passed,passed$(RAND),g
 
 test: randomize
 	python3 overwrite.py $(CHAPTER)


### PR DESCRIPTION
sed 在 linux 下和 macos 表现不一致，导致 make test 在 macos失败，使用 perl 代替 sed 的功能解决该问题。目前在 ubuntu 20.04.3 和 macos 下测试通过，理论上 perl 在不同平台下表现一致。