### PR TITLE
Fix: Used but undeclared macro 'asm!'.

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -1,25 +1,25 @@
 # 常见问题解答
 
-## Q0：GitHub classroom是啥？如何使用？
+## Q0：GitHub classroom 是啥？如何使用？
 
-### A:
+### A：
 
-     - [B站的GitHub Classroom 视频介绍](https://www.bilibili.com/video/BV12L41147r7?spm_id_from=333.337.search-card.all.click&vd_source=8e19ee6e49f598fda8c17e306d8b3726) 
-     - [Youtube的GitHub Classroom视频介绍](https://www.youtube.com/playlist?list=PLIRjfNq867bewk3ZGV6Z7a16YDNRCpK3u)
-     - [github文档：使用 GitHub Classroom 教学](https://docs.github.com/cn/education/manage-coursework-with-github-classroom/get-started-with-github-classroom)
+     - [B 站的 GitHub Classroom 视频介绍](https://www.bilibili.com/video/BV12L41147r7?spm_id_from=333.337.search-card.all.click&vd_source=8e19ee6e49f598fda8c17e306d8b3726) 
+     - [Youtube 的 GitHub Classroom 视频介绍](https://www.youtube.com/playlist?list=PLIRjfNq867bewk3ZGV6Z7a16YDNRCpK3u)
+     - [GitHub 文档：使用 GitHub Classroom 教学](https://docs.github.com/cn/education/manage-coursework-with-github-classroom/get-started-with-github-classroom)
   
-## Q1：已经在classroom中建立了自己的仓库（例如 “LearningOS/lab0-0-setup-env-run-os1-chyyuu2022"），但是源仓库“LearningOS/rust-based-os-comp2022“更新了，如何处理？
+## Q1：已经在 classroom 中建立了自己的仓库（例如“LearningOS/lab0-0-setup-env-run-os1-chyyuu2022”），但是源仓库“LearningOS/rust-based-os-comp2022”更新了，如何处理？
 
 ### A：
 
 **方法一：**
 
-      重新点击加入课程的链接，在页面下方会有一行字“We've configured the repository associated with this assignment (update)”，“update”是一个链接，点击update就可以把自己的仓库更新到与最新状态的repository template一致。
+    重新点击加入课程的链接，在页面下方会有一行字“We've configured the repository associated with this assignment (update)”，“update”是一个链接，点击 update 就可以把自己的仓库更新到与最新状态的 repository template 一致。
 
 ​      
 **方法二：**
 
-​     在自己构建的仓库根目录下执行以下命令:
+在自己构建的仓库根目录下执行以下命令：
 
 ```makefile
 git remote add upstream "https://github.com/LearningOS/rust-based-os-comp2022.git"
@@ -35,49 +35,71 @@ git push -f
   
     向管理员“助教许善朴”申请删除已生成仓库，再点击 链接重新创建仓库。
 
-##  Q2：在classroom中建立了自己的仓库中，进行提交 `git push` 后，触发 CI后，出现 Annotations 错误“The job was not stared because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings”，无法完成自动CI功能，比如 `Autograding` 等。
+##  Q2：在 classroom 中建立了自己的仓库中，进行提交 `git push` 后，触发 CI 后，出现 Annotations 错误“The job was not stared because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings”，无法完成自动 CI 功能，比如 `Autograding` 等。
 
-### A:
+### A：
 
 **方法一：**
     
-    这是由于对用户的私有仓库进行CI 相关的github action是需要付费的。用户可通过给自己的github账户充值来解决。https://docs.github.com/cn/billing/managing-billing-for-github-actions/about-billing-for-github-actions 给出了具体信息。
+    这是由于对用户的私有仓库进行 CI 相关的 GitHub Action 是需要付费的。用户可通过给自己的 github 账户充值来解决。https://docs.github.com/cn/billing/managing-billing-for-github-actions/about-billing-for-github-actions 给出了具体信息。
 
 **方法二：**
 
-    对用户的公开仓库进行CI github action是不需要付费的。在项目的 `Settings` -> `Change visibility` 将项目改成Public, 重新触发Action。 
-    目前设置了让用户具有修改自己的项目从private --> public的能力。
+    对用户的公开仓库进行 CI GitHub Action 是不需要付费的。在项目的 `Settings` -> `Change visibility` 将项目改成 Public, 重新触发 Action。 
+    目前设置了让用户具有修改自己的项目从 private --> public 的能力。
     如果用户还是发现自己的权限不够，或看不到  `Settings`  这个选项，可以通过联系助教帮助来解决。
 
-## Q3：我刚开始准备学习Rust，是Rust新手，我应该如何入门？
+## Q3：我刚开始准备学习 Rust，是 Rust 新手，我应该如何入门？
 
-### A:
+### A：
 
   - [Rust 大佬给初学者的学习建议](https://github.com/rustlang-cn/Rustt/blob/main/Articles/%5B2022-04-02%5D%20Rust%20%E5%A4%A7%E4%BD%AC%E7%BB%99%E5%88%9D%E5%AD%A6%E8%80%85%E7%9A%84%E5%AD%A6%E4%B9%A0%E5%BB%BA%E8%AE%AE.md)
   - [张汉东：学习 Rust 你需要一个认知框架](https://zhuanlan.zhihu.com/p/494001676)
-  - [Rust语言圣经(Rust Course)](https://course.rs/)
-  - [Rust速查表（cheatsheet）](https://cheats.rs/) 该项目不仅提供了基础的语法速查，还有执行顺序详解和编写时需要关注的注意事项。项目还包含了示例代码（EX）、书籍（BK）、标准（STD）等相关资料的扩展。
+  - [Rust 语言圣经（Rust Course）](https://course.rs/)
+  - [Rust 速查表（cheatsheet）](https://cheats.rs/) 该项目不仅提供了基础的语法速查，还有执行顺序详解和编写时需要关注的注意事项。项目还包含了示例代码（EX）、书籍（BK）、标准（STD）等相关资料的扩展。
 
-## Q4：我不熟悉GitHub和Git，有啥快速入门的资源吗？
+## Q4：我不熟悉 GitHub 和 Git，有啥快速入门的资源吗？
 
-### A:
+### A：
 
-   - [包括：从 0 开始学习 GitHub 系列1-7](https://jtxiao.com/main/categories/%E5%B7%A5%E5%85%B7/)
-   - [超级简单的Git入门](https://backlog.com/git-tutorial/cn/)
+   - [包括：从 0 开始学习 GitHub 系列 1-7](https://jtxiao.com/main/categories/%E5%B7%A5%E5%85%B7/)
+   - [超级简单的 Git 入门](https://backlog.com/git-tutorial/cn/)
    - [git - 简明指南](https://rogerdudler.github.io/git-guide/index.zh.html)
-   - [中文git-tips](https://github.com/521xueweihan/git-tips)
+   - [中文 git-tips](https://github.com/521xueweihan/git-tips)
    - [GitHub 官方制作的 Git 速查表](https://education.github.com/git-cheat-sheet-education.pdf)
 
-## Q5：我不熟悉Linux的各种命令，有啥快速入门的资源吗？
+## Q5：我不熟悉 Linux 的各种命令，有啥快速入门的资源吗？
 
-### A:
+### A：
 
-   - [中文Linux命令（linux-command）搜索引擎](https://wangchujiang.com/linux-command/)：随用随搜Linux命令，而且还支持中文搜索
+   - [中文 Linux 命令（linux-command）搜索引擎](https://wangchujiang.com/linux-command/)：随用随搜 Linux 命令，而且还支持中文搜索
    - [新版 Linux 命令百科全书》（英文）](https://github.com/tldr-pages/tldr)
 
-## Q6：我碰到一些命令/应用(比如vim, curl)、操作（比如vscode）或语言用法（比如Makefile）等不知到哪里能快速查找，怎么办？
+## Q6：我碰到一些命令/应用（比如 vim, curl）、操作（比如 vscode）或语言用法（比如 Makefile）等不知到哪里能快速查找，怎么办？
   
-### A:
+### A：
 
    - [Rico's cheatsheets](https://devhints.io/) 开源、全面的速查表网站，涵盖了前端、后端、运维、IDE 多个方面，而且界面友好简洁支持在线查看
-   - [所有与命令行相关的cheatsheet](http://cheat.sh/)：号称「你唯一需要的命令行相关速查表」
+   - [所有与命令行相关的 cheatsheet](http://cheat.sh/)：号称「你唯一需要的命令行相关速查表」
+
+## Q7：我可以正常 `make run`，但使用 `make test` 命令后，构件过程报了许多错（`asm!` not found in scope），Autograding 也无法通过，怎么办？
+
+### A：
+
+这是由于内置的 `ci-user/riscv` 代码有错误，在 Autograding 时远程的 `riscv` 依赖被替换，导致编译失败。
+
+**方法一：**
+
+    替换内置的 riscv 至正常版本，直接删除本地 `ci-user/riscv` 文件夹，替换为 [ Yakkhini / rust-based-os-comp2022](https://github.com/Yakkhini/rust-based-os-comp2022/tree/main/ci-user) 同位置的修复版本 `/riscv`。
+
+**方法二：**
+
+    删除 `ci-user/overwrite.py` 21 行以下部分的依赖替换脚本。
+
+**方法三：**
+
+    替换你实验文件夹中 `Cargo.toml` 的 riscv 依赖网址为 `https://GitHub.com/rcore-os/riscv`（修改了网址的大小写）或 `https://gitee.com/rcore-os/riscv`（改为 Gitee 源），使脚本中的替换匹配失效。
+
+**方法四：**
+
+    如果你能看到这个 QA，说明相关 Pull request 已被 merge，可以按 QA1 中方法更新仓库。

--- a/ci-user/riscv/src/asm.rs
+++ b/ci-user/riscv/src/asm.rs
@@ -7,7 +7,7 @@ macro_rules! instruction {
         pub unsafe fn $fnname() {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!($asm),
+                () => core::arch::asm!($asm),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -58,7 +58,7 @@ instruction!(
 pub unsafe fn sfence_vma(asid: usize, addr: usize) {
     match () {
         #[cfg(all(riscv, feature = "inline-asm"))]
-        () => asm!("sfence.vma {0}, {1}", in(reg) asid, in(reg) addr),
+        () => core::arch::asm!("sfence.vma {0}, {1}", in(reg) asid, in(reg) addr),
 
         #[cfg(all(riscv, not(feature = "inline-asm")))]
         () => {
@@ -87,7 +87,7 @@ mod hypervisor_extension {
                 match () {
                     #[cfg(all(riscv, feature = "inline-asm"))]
                     // Since LLVM does not recognize the two registers, we assume they are placed in a0 and a1, correspondingly.
-                    () => asm!($asm, in("x10") rs1, in("x11") rs2),
+                    () => core::arch::asm!($asm, in("x10") rs1, in("x11") rs2),
 
                     #[cfg(all(riscv, not(feature = "inline-asm")))]
                     () => {
@@ -112,7 +112,7 @@ mod hypervisor_extension {
                     #[cfg(all(riscv, feature = "inline-asm"))]
                     () => {
                         let mut result : usize;
-                        asm!($asm, inlateout("x10") rs1 => result);
+                        core::arch::asm!($asm, inlateout("x10") rs1 => result);
                         return result;
                     }
 

--- a/ci-user/riscv/src/lib.rs
+++ b/ci-user/riscv/src/lib.rs
@@ -14,7 +14,7 @@
 //! - Wrappers around assembly instructions like `WFI`.
 
 #![no_std]
-#![cfg_attr(feature = "inline-asm", feature(asm))]
+#![cfg_attr(feature = "inline-asm", feature(asm_const))]
 extern crate bare_metal;
 #[macro_use]
 extern crate bitflags;

--- a/ci-user/riscv/src/register/macros.rs
+++ b/ci-user/riscv/src/register/macros.rs
@@ -7,7 +7,7 @@ macro_rules! read_csr {
                 #[cfg(all(riscv, feature = "inline-asm"))]
                 () => {
                     let r: usize;
-                    asm!("csrrs {0}, {1}, x0", out(reg) r, const $csr_number);
+                    core::arch::asm!("csrrs {0}, {1}, x0", out(reg) r, const $csr_number);
                     r
                 }
 
@@ -36,7 +36,7 @@ macro_rules! read_csr_rv32 {
                 #[cfg(all(riscv32, feature = "inline-asm"))]
                 () => {
                     let r: usize;
-                    asm!("csrrs {0}, {1}, x0", out(reg) r, const $csr_number);
+                    core::arch::asm!("csrrs {0}, {1}, x0", out(reg) r, const $csr_number);
                     r
                 }
 
@@ -102,7 +102,7 @@ macro_rules! write_csr {
         unsafe fn _write(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!("csrrw x0, {1}, {0}", in(reg) bits, const $csr_number),
+                () => core::arch::asm!("csrrw x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -128,7 +128,7 @@ macro_rules! write_csr_rv32 {
         unsafe fn _write(bits: usize) {
             match () {
                 #[cfg(all(riscv32, feature = "inline-asm"))]
-                () => asm!("csrrw x0, {1}, {0}", in(reg) bits, const $csr_number),
+                () => core::arch::asm!("csrrw x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv32, not(feature = "inline-asm")))]
                 () => {
@@ -178,7 +178,7 @@ macro_rules! set {
         unsafe fn _set(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!("csrrs x0, {1}, {0}", in(reg) bits, const $csr_number),
+                () => core::arch::asm!("csrrs x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -204,7 +204,7 @@ macro_rules! clear {
         unsafe fn _clear(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!("csrrc x0, {1}, {0}", in(reg) bits, const $csr_number),
+                () => core::arch::asm!("csrrc x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {


### PR DESCRIPTION
It‘s an **EMERGENCY** fix!

I noticed that almost **every** lab repo autograding failed cause incorrect use of `asm!` macro in built-in riscv dependency, except:

* They change their `os2/Cargo.toml`, make the riscv source to Gitee. In this case, line replace function in `overwrite.py` can't replace riscv to path `../ci-user/riscv`
* They just delete the replace function in `overwrite.py`, like [ Do not overwrite the riscv to local copy #17 ](https://github.com/LearningOS/rust-based-os-comp2022/pull/17)
* They didn't set up classroom autograding in GitHub Actions, the deploy action works fine.

The built-in riscv dependency in `ci-user` must be unusable.

You said `make test2` works fine in your environment, please check if your riscv source in `Cargo.toml` changed to Gitee, or your riscv's macro is correctly writed.

See more deep information, please check [this commit](https://github.com/rcore-os/riscv/commit/11d43cf7cccb3b62a3caaf3e07a1db7449588f9a).