### PR TITLE
add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: 发现Bug时请提此类型Issue帮助改进
+title: '[Bug] 标题示例: 编译失败'
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Ubuntu]
+ - Rust Version:
+ - QEMU Version:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: 为项目提建议
+title: '[Feature] 标题示例: 建议增加QA章节'
+labels: 'feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,24 @@
+---
+name: Question
+about: 对课程内容有疑问请提此类型Issue
+title: '[Question] 标题示例: 为什么这里需要添加&'
+labels: 'question'
+assignees: ''
+
+---
+
+**Describe the question**
+A clear and concise description of what the question is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/study_note.md
+++ b/.github/ISSUE_TEMPLATE/study_note.md
@@ -1,0 +1,14 @@
+---
+name: Study Note
+about: 记录学习过程
+title: '[Note] 标题示例: 第x章学习笔记总结'
+labels: 'note'
+assignees: ''
+
+---
+
+**Chapter**
+e.g. 第二章 批处理系统
+
+**Study Note**
+学习笔记整理


### PR DESCRIPTION
Hi!

Some Github Issue Templates are added so that we can classify the issues.

To make it works, extra labels are needed (`bug`, `feature`, `note`, `question`).

PTAL~