### PR TITLE
[os4-ref] fix : TaskStatus in kernel is different from TaskStatus in user mode.

### DIFF
--- a/os4-ref/src/task/task.rs
+++ b/os4-ref/src/task/task.rs
@@ -58,6 +58,7 @@ impl TaskControlBlock {
 #[derive(Copy, Clone, PartialEq)]
 /// task status: UnInit, Ready, Running, Exited
 pub enum TaskStatus {
+    UnInit,
     Ready,
     Running,
     Exited,


### PR DESCRIPTION
在当前的 os4-ref 代码中， 内核中赋值为TaskStatus::Running的字段将被在用户态错误解释为TaskStatus::Ready
原因是TaskStatus的实现不同：
用户态中TaskStatus：
`pub enum TaskStatus {
    UnInit,
    Ready,
    Running,
    Exited,
}`
内核中TaskStatus：
`pub enum TaskStatus {
    Ready,
    Running,
    Exited,
}`

