### PR TITLE
fix: make the kernel stack size identical to the config in os3-ref

### DIFF
--- a/os3/src/config.rs
+++ b/os3/src/config.rs
@@ -1,5 +1,5 @@
-pub const USER_STACK_SIZE: usize = 8192;
-pub const KERNEL_STACK_SIZE: usize = 8192 * 20;
+pub const USER_STACK_SIZE: usize = 4096;
+pub const KERNEL_STACK_SIZE: usize = 4096 * 20;
 pub const KERNEL_HEAP_SIZE: usize = 0x20000;
 pub const MAX_APP_NUM: usize = 16;
 pub const APP_BASE_ADDRESS: usize = 0x80400000;


### PR DESCRIPTION
The config `KERNEL_STACK_SIZE` in os3 was set as 8192 * 20, while qemu doesn't preserve enough memory, thus making the core dumped.